### PR TITLE
VAST-73: Migrate from NPM to GitHub Packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Publish to GitHub Packages
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://npm.pkg.github.com
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-//registry.npmjs.org/:_authToken=${ARTE_NPM_TOKEN}
+@artegie:registry=https://npm.pkg.github.com

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,42 +1,9 @@
-## [1.5.4](https://github.com/ArteGEIE/videojs-vast/compare/1.5.3...1.5.4) (2026-02-06)
+## [Unreleased]
 
+### Changed
 
-
-## [1.5.4](https://github.com/ArteGEIE/videojs-vast/compare/1.5.3...1.5.4) (2026-02-06)
-
-
-
-## [1.5.4](https://github.com/ArteGEIE/videojs-vast/compare/1.5.3...1.5.4) (2026-02-06)
-
-
-
-## [1.5.4](https://github.com/ArteGEIE/videojs-vast/compare/1.5.3...1.5.4) (2026-02-06)
-
-
-
-## [1.5.4](https://github.com/ArteGEIE/videojs-vast/compare/1.5.3...1.5.4) (2026-02-06)
-
-
-
-## [1.5.4](https://github.com/ArteGEIE/videojs-vast/compare/1.5.3...1.5.4) (2026-02-06)
-
-
-
-## [1.5.4](https://github.com/ArteGEIE/videojs-vast/compare/1.5.3...1.5.4) (2026-02-06)
-
-
-
-## [1.5.4](https://github.com/ArteGEIE/videojs-vast/compare/1.5.3...1.5.4) (2026-02-06)
-
-
-
-## [1.5.4](https://github.com/ArteGEIE/videojs-vast/compare/1.5.3...1.5.4) (2026-02-06)
-
-
-
-## [1.5.4](https://github.com/ArteGEIE/videojs-vast/compare/1.5.3...1.5.4) (2026-02-06)
-
-
+- **VAST-73:** Migrate package from NPM to GitHub Packages (`@artegie/videojs-vast`)
+- Add GitHub Actions workflow for automated publishing on tag push
 
 ## [1.5.4](https://github.com/ArteGEIE/videojs-vast/compare/1.5.3...1.5.4) (2026-02-06)
 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,17 @@ Table of contents
 
 In order to start using the VAST Plugin you are supposed to have started a project that consumes VideosJS and have some basic knowledge of its basic concepts and API. To get started, install and include this package in your project's dependencies using npm or yarn:
 
+First, configure your `.npmrc` to use GitHub Packages for the `@artegie` scope:
+
 ```
-npm install --save @arte/videojs-vast
-yarn add @arte/videojs-vast
+@artegie:registry=https://npm.pkg.github.com
+```
+
+Then install the package:
+
+```
+npm install --save @artegie/videojs-vast
+yarn add @artegie/videojs-vast
 ```
 
 Now, import the plugin package and initialize it right after initializing your VideoJS instance. Here's a small snipet that of what it could look like:
@@ -39,7 +47,7 @@ Now, import the plugin package and initialize it right after initializing your V
 ```
 // Import the necessary packages
 import videojs from 'video.js';
-import '@arte/videojs-vast';
+import '@artegie/videojs-vast';
 
 // Create VideoJS instance
 const videoJsInstance = videojs('my-player', {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@arte/videojs-vast",
+  "name": "@artegie/videojs-vast",
   "version": "1.5.4",
   "main": "./dist/cjs/index.js",
   "module": "./dist/mjs/index.js",


### PR DESCRIPTION
## Summary

- Rename package scope from `@arte/videojs-vast` to `@artegie/videojs-vast`
- Configure `.npmrc` for GitHub Packages registry
- Add GitHub Actions workflow for automated publishing on tag push (`v*`)
- Update README with new installation instructions
- Clean up duplicate entries in CHANGELOG

## Release flow

1. `npm run release` (bump version, changelog, git tag)
2. `git push --follow-tags` → tag triggers the workflow → auto-publish to GitHub Packages