### PR TITLE
fix: rename ressource to resource (VAST-78)

### DIFF
--- a/src/modes/companions.js
+++ b/src/modes/companions.js
@@ -11,26 +11,26 @@ export function playCompanionAd(creative) {
     // image
     if (variation.staticResources && variation.staticResources.length > 0) {
       variation.staticResources.map((staticResource) => {
-        const ressourceContainer = document.createElement('div');
-        this.domElements.push(ressourceContainer);
-        ressourceContainer.width = variation.staticResources.width > 0 ? variation.staticResources.width : 100;
-        ressourceContainer.height = variation.staticResources.height > 0 ? variation.staticResources.height : 100;
-        ressourceContainer.style.maxWidth = variation.staticResources.expandedWidth;
-        ressourceContainer.style.maxHeight = variation.staticResources.expandedHeight;
-        applyNonLinearCommonDomStyle(ressourceContainer);
+        const resourceContainer = document.createElement('div');
+        this.domElements.push(resourceContainer);
+        resourceContainer.width = variation.staticResources.width > 0 ? variation.staticResources.width : 100;
+        resourceContainer.height = variation.staticResources.height > 0 ? variation.staticResources.height : 100;
+        resourceContainer.style.maxWidth = variation.staticResources.expandedWidth;
+        resourceContainer.style.maxHeight = variation.staticResources.expandedHeight;
+        applyNonLinearCommonDomStyle(resourceContainer);
 
-        const ressource = document.createElement('img');
-        this.domElements.push(ressourceContainer);
-        ressource.addEventListener('click', () => {
+        const resource = document.createElement('img');
+        this.domElements.push(resourceContainer);
+        resource.addEventListener('click', () => {
           window.open(variation.companionClickThroughURLTemplate, '_blank');
           this.companionVastTracker.click(null, this.macros);
         });
-        ressource.src = staticResource.url;
-        ressourceContainer.appendChild(ressource);
+        resource.src = staticResource.url;
+        resourceContainer.appendChild(resource);
         if (variation.adSlotID) {
-          document.querySelector(`#${variation.adSlotID}`).appendChild(ressourceContainer);
+          document.querySelector(`#${variation.adSlotID}`).appendChild(resourceContainer);
         } else {
-          this.player.el().appendChild(ressourceContainer);
+          this.player.el().appendChild(resourceContainer);
         }
         return staticResource;
       });
@@ -39,22 +39,22 @@ export function playCompanionAd(creative) {
     // html
     if (variation.htmlResources) {
       variation.htmlResources.map((htmlResource) => {
-        const ressourceContainer = document.createElement('div');
-        this.domElements.push(ressourceContainer);
-        ressourceContainer.width = variation.htmlResources.width;
-        ressourceContainer.height = variation.htmlResources.height;
-        ressourceContainer.style.maxWidth = variation.htmlResources.expandedWidth;
-        ressourceContainer.style.maxHeight = variation.htmlResources.expandedHeight;
-        applyNonLinearCommonDomStyle(ressourceContainer);
-        ressourceContainer.addEventListener('click', () => {
+        const resourceContainer = document.createElement('div');
+        this.domElements.push(resourceContainer);
+        resourceContainer.width = variation.htmlResources.width;
+        resourceContainer.height = variation.htmlResources.height;
+        resourceContainer.style.maxWidth = variation.htmlResources.expandedWidth;
+        resourceContainer.style.maxHeight = variation.htmlResources.expandedHeight;
+        applyNonLinearCommonDomStyle(resourceContainer);
+        resourceContainer.addEventListener('click', () => {
           window.open(variation.companionClickThroughURLTemplate, '_blank');
           this.companionVastTracker.click(null, this.macros);
         });
-        ressourceContainer.innerHTML = htmlResource;
+        resourceContainer.innerHTML = htmlResource;
         if (variation.adSlotID) {
-          document.querySelector(`#${variation.adSlotID}`).appendChild(ressourceContainer);
+          document.querySelector(`#${variation.adSlotID}`).appendChild(resourceContainer);
         } else {
-          this.player.el().appendChild(ressourceContainer);
+          this.player.el().appendChild(resourceContainer);
         }
         return htmlResource;
       });
@@ -63,22 +63,22 @@ export function playCompanionAd(creative) {
     // iframe
     if (variation.iframeResources) {
       variation.iframeResources.map((iframeResource) => {
-        const ressourceContainer = document.createElement('div');
-        this.domElements.push(ressourceContainer);
-        ressourceContainer.width = variation.iframeResources.width;
-        ressourceContainer.height = variation.iframeResources.height;
-        ressourceContainer.style.maxWidth = variation.iframeResources.expandedWidth;
-        ressourceContainer.style.maxHeight = variation.iframeResources.expandedHeight;
-        applyNonLinearCommonDomStyle(ressourceContainer);
-        ressourceContainer.addEventListener('click', () => {
+        const resourceContainer = document.createElement('div');
+        this.domElements.push(resourceContainer);
+        resourceContainer.width = variation.iframeResources.width;
+        resourceContainer.height = variation.iframeResources.height;
+        resourceContainer.style.maxWidth = variation.iframeResources.expandedWidth;
+        resourceContainer.style.maxHeight = variation.iframeResources.expandedHeight;
+        applyNonLinearCommonDomStyle(resourceContainer);
+        resourceContainer.addEventListener('click', () => {
           window.open(variation.companionClickThroughURLTemplate, '_blank');
           this.companionVastTracker.click(null, this.macros);
         });
-        ressourceContainer.src = iframeResource;
+        resourceContainer.src = iframeResource;
         if (variation.adSlotID) {
-          document.querySelector(`#${variation.adSlotID}`).appendChild(ressourceContainer);
+          document.querySelector(`#${variation.adSlotID}`).appendChild(resourceContainer);
         } else {
-          this.player.el().appendChild(ressourceContainer);
+          this.player.el().appendChild(resourceContainer);
         }
         return iframeResource;
       });

--- a/src/modes/nonlinear.js
+++ b/src/modes/nonlinear.js
@@ -9,85 +9,85 @@ export function playNonLinearAd(creative) {
 
     // image
     if (variation.staticResource) {
-      const ressourceContainer = document.createElement('div');
-      this.domElements.push(ressourceContainer);
-      applyNonLinearCommonDomStyle(ressourceContainer);
+      const resourceContainer = document.createElement('div');
+      this.domElements.push(resourceContainer);
+      applyNonLinearCommonDomStyle(resourceContainer);
 
-      const ressource = document.createElement('img');
-      ressource.addEventListener('click', () => {
+      const resource = document.createElement('img');
+      resource.addEventListener('click', () => {
         window.open(variation.nonlinearClickThroughURLTemplate, '_blank');
         this.nonLinearVastTracker.click(null, this.macros);
       });
-      ressourceContainer.style.maxWidth = variation.expandedWidth;
-      ressourceContainer.style.maxHeight = variation.expandedHeight;
-      ressource.src = variation.staticResource;
+      resourceContainer.style.maxWidth = variation.expandedWidth;
+      resourceContainer.style.maxHeight = variation.expandedHeight;
+      resource.src = variation.staticResource;
 
       // add close button
-      const closeButton = getCloseButton(() => ressourceContainer.remove());
+      const closeButton = getCloseButton(() => resourceContainer.remove());
       closeButton.style.display = variation.minSuggestedDuration ? 'none' : 'block';
 
       if (variation.minSuggestedDuration) {
         setTimeout(() => {
           closeButton.style.display = 'block';
-          ressourceContainer.appendChild(closeButton);
+          resourceContainer.appendChild(closeButton);
         }, variation.minSuggestedDuration * 1000);
       }
-      ressourceContainer.appendChild(ressource);
+      resourceContainer.appendChild(resource);
       if (variation.adSlotID) {
-        document.querySelector(`#${variation.adSlotID}`).appendChild(ressourceContainer);
+        document.querySelector(`#${variation.adSlotID}`).appendChild(resourceContainer);
       } else {
-        this.player.el().appendChild(ressourceContainer);
+        this.player.el().appendChild(resourceContainer);
       }
     }
 
     // html
     if (variation.htmlResource) {
-      const ressourceContainer = document.createElement('div');
-      this.domElements.push(ressourceContainer);
-      applyNonLinearCommonDomStyle(ressourceContainer);
-      ressourceContainer.addEventListener('click', () => {
+      const resourceContainer = document.createElement('div');
+      this.domElements.push(resourceContainer);
+      applyNonLinearCommonDomStyle(resourceContainer);
+      resourceContainer.addEventListener('click', () => {
         window.open(variation.nonlinearClickThroughURLTemplate, '_blank');
         this.nonLinearVastTracker.click(null, this.macros);
       });
 
-      ressourceContainer.style.maxWidth = variation.expandedWidth;
-      ressourceContainer.style.maxHeight = variation.expandedHeight;
-      ressourceContainer.innerHTML = variation.htmlResource;
+      resourceContainer.style.maxWidth = variation.expandedWidth;
+      resourceContainer.style.maxHeight = variation.expandedHeight;
+      resourceContainer.innerHTML = variation.htmlResource;
 
       if (variation.adSlotID) {
-        document.querySelector(`#${variation.adSlotID}`).appendChild(ressourceContainer);
+        document.querySelector(`#${variation.adSlotID}`).appendChild(resourceContainer);
       } else {
-        this.player.el().appendChild(ressourceContainer);
+        this.player.el().appendChild(resourceContainer);
       }
       if (variation.minSuggestedDuration) {
         setTimeout(() => {
-          ressourceContainer.remove();
+          resourceContainer.remove();
         }, variation.minSuggestedDuration * 1000);
       }
     }
 
     // iframe
     if (variation.iframeResource) {
-      const ressourceContainer = document.createElement('iframe');
-      this.domElements.push(ressourceContainer);
-      applyNonLinearCommonDomStyle(ressourceContainer);
-      ressourceContainer.addEventListener('click', () => {
+      const resourceContainer = document.createElement('iframe');
+      this.domElements.push(resourceContainer);
+      applyNonLinearCommonDomStyle(resourceContainer);
+      resourceContainer.addEventListener('click', () => {
         window.open(variation.nonlinearClickThroughURLTemplate, '_blank');
         this.nonLinearVastTracker.click(null, this.macros);
       });
 
-      ressourceContainer.style.maxWidth = variation.expandedWidth;
-      ressourceContainer.style.maxHeight = variation.expandedHeight;
+      resourceContainer.style.maxWidth = variation.expandedWidth;
+      resourceContainer.style.maxHeight = variation.expandedHeight;
 
-      ressourceContainer.src = variation.iframeResource;
+      resourceContainer.src = variation.iframeResource;
       if (variation.adSlotID) {
-        document.querySelector(`#${variation.adSlotID}`).appendChild(ressourceContainer);
+        document.querySelector(`#${variation.adSlotID}`).appendChild(resourceContainer);
       } else {
-        this.player.el().appendChild(ressourceContainer);
+        this.player.el().appendChild(resourceContainer);
       }
       if (variation.minSuggestedDuration) {
         setTimeout(() => {
-          ressourceContainer.remove();
+          resourceContainer.remove();
         }, variation.minSuggestedDuration * 1000);
       }
     }


### PR DESCRIPTION
## Summary
- Rename French spelling typo `ressourceContainer` → `resourceContainer` and `ressource` → `resource` in variable names
- Affects `src/modes/companions.js` and `src/modes/nonlinear.js`
- No functional change — rename only

## Test plan
- [x] Build passes
- [x] Lint passes
- [ ] E2E tests pass (companion and nonlinear ad rendering unchanged)