### PR TITLE
fix: add null checks for querySelector in companions/nonlinear (VAST-82)

### DIFF
--- a/src/modes/companions.js
+++ b/src/modes/companions.js
@@ -28,7 +28,12 @@ export function playCompanionAd(creative) {
         resource.src = staticResource.url;
         resourceContainer.appendChild(resource);
         if (variation.adSlotID) {
-          document.querySelector(`#${variation.adSlotID}`).appendChild(resourceContainer);
+          const adSlot = document.querySelector(`#${variation.adSlotID}`);
+          if (adSlot) {
+            adSlot.appendChild(resourceContainer);
+          } else {
+            console.warn(`VastVjs: adSlotID #${variation.adSlotID} not found in DOM`);
+          }
         } else {
           this.player.el().appendChild(resourceContainer);
         }
@@ -51,7 +56,12 @@ export function playCompanionAd(creative) {
         });
         resourceContainer.innerHTML = htmlResource;
         if (variation.adSlotID) {
-          document.querySelector(`#${variation.adSlotID}`).appendChild(resourceContainer);
+          const adSlot = document.querySelector(`#${variation.adSlotID}`);
+          if (adSlot) {
+            adSlot.appendChild(resourceContainer);
+          } else {
+            console.warn(`VastVjs: adSlotID #${variation.adSlotID} not found in DOM`);
+          }
         } else {
           this.player.el().appendChild(resourceContainer);
         }
@@ -74,7 +84,12 @@ export function playCompanionAd(creative) {
         });
         resourceContainer.src = iframeResource;
         if (variation.adSlotID) {
-          document.querySelector(`#${variation.adSlotID}`).appendChild(resourceContainer);
+          const adSlot = document.querySelector(`#${variation.adSlotID}`);
+          if (adSlot) {
+            adSlot.appendChild(resourceContainer);
+          } else {
+            console.warn(`VastVjs: adSlotID #${variation.adSlotID} not found in DOM`);
+          }
         } else {
           this.player.el().appendChild(resourceContainer);
         }

--- a/src/modes/nonlinear.js
+++ b/src/modes/nonlinear.js
@@ -34,7 +34,12 @@ export function playNonLinearAd(creative) {
       }
       resourceContainer.appendChild(resource);
       if (variation.adSlotID) {
-        document.querySelector(`#${variation.adSlotID}`).appendChild(resourceContainer);
+        const adSlot = document.querySelector(`#${variation.adSlotID}`);
+        if (adSlot) {
+          adSlot.appendChild(resourceContainer);
+        } else {
+          console.warn(`VastVjs: adSlotID #${variation.adSlotID} not found in DOM`);
+        }
       } else {
         this.player.el().appendChild(resourceContainer);
       }
@@ -55,7 +60,12 @@ export function playNonLinearAd(creative) {
       resourceContainer.innerHTML = variation.htmlResource;
 
       if (variation.adSlotID) {
-        document.querySelector(`#${variation.adSlotID}`).appendChild(resourceContainer);
+        const adSlot = document.querySelector(`#${variation.adSlotID}`);
+        if (adSlot) {
+          adSlot.appendChild(resourceContainer);
+        } else {
+          console.warn(`VastVjs: adSlotID #${variation.adSlotID} not found in DOM`);
+        }
       } else {
         this.player.el().appendChild(resourceContainer);
       }
@@ -81,7 +91,12 @@ export function playNonLinearAd(creative) {
 
       resourceContainer.src = variation.iframeResource;
       if (variation.adSlotID) {
-        document.querySelector(`#${variation.adSlotID}`).appendChild(resourceContainer);
+        const adSlot = document.querySelector(`#${variation.adSlotID}`);
+        if (adSlot) {
+          adSlot.appendChild(resourceContainer);
+        } else {
+          console.warn(`VastVjs: adSlotID #${variation.adSlotID} not found in DOM`);
+        }
       } else {
         this.player.el().appendChild(resourceContainer);
       }


### PR DESCRIPTION
## Summary
- Guard `document.querySelector()` results before calling `.appendChild()` in companion and nonlinear ad modes
- If `adSlotID` element is missing from the DOM, emit `console.warn` and skip rendering gracefully instead of crashing
- Affects `src/modes/companions.js` (3 locations) and `src/modes/nonlinear.js` (3 locations)

## Test plan
- [x] Build passes
- [x] Lint passes
- [ ] E2E tests pass (companions and nonlinear rendering)
- [ ] No crash when adSlotID element is missing from the page