### PR TITLE
fix: sanitize HTML content from VAST creatives (VAST-81)

### DIFF
--- a/src/features/icons.js
+++ b/src/features/icons.js
@@ -1,4 +1,4 @@
-import { isNumeric } from '../lib';
+import { isNumeric, sanitizeHtml } from '../lib';
 
 export function addIcons(ad) {
   const { icons } = ad.linearCreative();
@@ -17,7 +17,7 @@ export function addIcons(ad) {
         iconContainer.width = width > 0 ? width : 100;
       } else if (htmlResource) {
         iconContainer = document.createElement('div');
-        iconContainer.innerHTML = icon.htmlResource;
+        iconContainer.innerHTML = sanitizeHtml(icon.htmlResource);
       } else if (iframeResource) {
         iconContainer = document.createElement('iframe');
         iconContainer.src = iframeResource;

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,3 +1,30 @@
+const DANGEROUS_EVENT_ATTRS = /^on\w+/i;
+const DANGEROUS_URI_PATTERN = /^\s*javascript\s*:/i;
+const DANGEROUS_TAGS = new Set(['script', 'object', 'embed', 'applet']);
+
+export const sanitizeHtml = (html) => {
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  const walk = (node) => {
+    const children = [...node.children];
+    children.forEach((child) => {
+      if (DANGEROUS_TAGS.has(child.tagName.toLowerCase())) {
+        child.remove();
+        return;
+      }
+      [...child.attributes].forEach((attr) => {
+        if (DANGEROUS_EVENT_ATTRS.test(attr.name)) {
+          child.removeAttribute(attr.name);
+        } else if (DANGEROUS_URI_PATTERN.test(attr.value)) {
+          child.removeAttribute(attr.name);
+        }
+      });
+      walk(child);
+    });
+  };
+  walk(doc.body);
+  return doc.body.innerHTML;
+};
+
 export const isNumeric = (str) => {
   if (typeof str === 'number') {
     return true;

--- a/src/modes/companions.js
+++ b/src/modes/companions.js
@@ -1,5 +1,5 @@
 /* eslint-disable max-len */
-import { applyNonLinearCommonDomStyle } from '../lib/utils';
+import { applyNonLinearCommonDomStyle, sanitizeHtml } from '../lib/utils';
 
 /*
 * This method is responsible for rendering a nonlinear ad
@@ -54,7 +54,7 @@ export function playCompanionAd(creative) {
           window.open(variation.companionClickThroughURLTemplate, '_blank');
           this.companionVastTracker.click(null, this.macros);
         });
-        resourceContainer.innerHTML = htmlResource;
+        resourceContainer.innerHTML = sanitizeHtml(htmlResource);
         if (variation.adSlotID) {
           const adSlot = document.querySelector(`#${variation.adSlotID}`);
           if (adSlot) {

--- a/src/modes/nonlinear.js
+++ b/src/modes/nonlinear.js
@@ -1,4 +1,4 @@
-import { applyNonLinearCommonDomStyle, getCloseButton } from '../lib/utils';
+import { applyNonLinearCommonDomStyle, getCloseButton, sanitizeHtml } from '../lib/utils';
 
 /*
 * This method is responsible for rendering a nonlinear ad
@@ -57,7 +57,7 @@ export function playNonLinearAd(creative) {
 
       resourceContainer.style.maxWidth = variation.expandedWidth;
       resourceContainer.style.maxHeight = variation.expandedHeight;
-      resourceContainer.innerHTML = variation.htmlResource;
+      resourceContainer.innerHTML = sanitizeHtml(variation.htmlResource);
 
       if (variation.adSlotID) {
         const adSlot = document.querySelector(`#${variation.adSlotID}`);


### PR DESCRIPTION
## Summary
- Add `sanitizeHtml()` utility in `src/lib/utils.js` using `DOMParser` (no external dependency)
- Strips `<script>`, `<object>`, `<embed>`, `<applet>` tags
- Removes inline event handlers (`onclick`, `onerror`, etc.) and `javascript:` URIs
- Applied to all `innerHTML` assignments for VAST creative content in:
  - `src/modes/companions.js` (htmlResources)
  - `src/modes/nonlinear.js` (htmlResource)
  - `src/features/icons.js` (htmlResource)

## Test plan
- [x] Build passes
- [x] Lint passes
- [ ] Legitimate HTML creatives (images, styled divs) still render correctly
- [ ] Script tags and event handlers are stripped from malicious VAST tags