### PR TITLE
fix: skip button interval cleanup on all exit paths (VAST-85)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -487,6 +487,7 @@ class Vast extends Plugin {
 
   onAdError = (evt) => {
     this.debug('aderror');
+    this.clearSkipInterval();
     // trigger a tracker error
     this.linearVastTracker?.error({
       ...this.macros,


### PR DESCRIPTION
## Summary
- Add `clearSkipInterval()` calls in `onAdError()` and `onAdTimeout()`
- Prevents `setInterval` leak when player is destroyed, ad errors, or ad times out
- `onDispose` and `resetPlayer` already had this cleanup

## Test plan
- [x] Build passes
- [x] Lint passes
- [ ] No interval leak after ad error or timeout