### PR TITLE
chore: replace XMLHttpRequest with fetch + AbortController (VAST-76)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -680,7 +680,7 @@ class Vast extends Plugin {
 
   async handleVMAP(vmapUrl) {
     try {
-      const vmap = await fetchVmapUrl(vmapUrl);
+      const vmap = await fetchVmapUrl(vmapUrl, this.options.timeout);
       if (vmap.adBreaks && vmap.adBreaks.length > 0) {
         this.addEventsListeners();
         // handle preroll

--- a/src/lib/fetchVmapUrl.js
+++ b/src/lib/fetchVmapUrl.js
@@ -1,18 +1,25 @@
 import VMAP from '@dailymotion/vmap';
 
-export const fetchVmapUrl = (url) => new Promise((resolve, reject) => {
-  const xhr = new XMLHttpRequest();
-  xhr.open('GET', url);
-  xhr.send();
-  xhr.onreadystatechange = () => {
-    if (xhr.readyState === xhr.DONE) {
-      if (xhr.status === 200) {
-        // Get a parsed VMAP object
-        const vmap = new VMAP(xhr.responseXML);
-        resolve(vmap);
-      } else {
-        reject(new Error('Error'));
-      }
+export const fetchVmapUrl = async (url, timeout = 5000) => {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      throw new Error(`VastVjs: VMAP fetch failed with status ${response.status}`);
     }
-  };
-});
+
+    const text = await response.text();
+    const xml = new DOMParser().parseFromString(text, 'text/xml');
+    return new VMAP(xml);
+  } catch (err) {
+    clearTimeout(timeoutId);
+    if (err.name === 'AbortError') {
+      throw new Error(`VastVjs: VMAP fetch timed out after ${timeout}ms`);
+    }
+    throw err;
+  }
+};


### PR DESCRIPTION
## Summary
- Rewrite `fetchVmapUrl()` in `src/lib/fetchVmapUrl.js` from XMLHttpRequest to fetch API
- Add `AbortController` with configurable timeout (uses plugin `timeout` option, default 5000ms)
- Meaningful error messages: network error vs timeout vs HTTP failure
- Parse response as text, then `DOMParser`, then `new VMAP()`
- Update `handleVMAP()` to pass `this.options.timeout`

## Test plan
- [x] Build passes
- [x] Lint passes
- [ ] VMAP fetching still works end-to-end
- [ ] Timeout triggers AbortError with clear message