### PR TITLE
refactor: improve code quality and fix return type bug

### DIFF
--- a/src/features/eventManager.js
+++ b/src/features/eventManager.js
@@ -1,0 +1,54 @@
+/*
+* Event binding configuration for the Vast plugin.
+* Each entry maps an event name to its handler method name on the plugin instance.
+* 'once' entries use player.one() instead of player.on().
+*/
+const playerEvents = [
+  { event: 'adplaying', handler: 'onAdPlay' },
+  { event: 'adpause', handler: 'onAdPause' },
+  { event: 'adtimeupdate', handler: 'onAdTimeUpdate' },
+  { event: 'advolumechange', handler: 'onAdVolumeChange' },
+  { event: 'adfullscreen', handler: 'onAdFullScreen' },
+  { event: 'adtimeout', handler: 'onAdTimeout' },
+  { event: 'adstart', handler: 'onAdStart' },
+  { event: 'aderror', handler: 'onAdError' },
+  { event: 'readyforpreroll', handler: 'onReadyForPreroll' },
+  { event: 'readyforpostroll', handler: 'onReadyForPostroll' },
+  { event: 'skip', handler: 'onSkip' },
+  { event: 'adended', handler: 'onAdEnded' },
+  { event: 'ended', handler: 'onEnded' },
+  { event: 'dispose', handler: 'onDispose' },
+];
+
+export function addEventsListeners() {
+  this.player.one('adplaying', this.onFirstPlay);
+  playerEvents.forEach(({ event, handler }) => {
+    this.player.on(event, this[handler]);
+  });
+  window.addEventListener('beforeunload', this.onUnload);
+}
+
+export function cleanupReadAdListeners() {
+  if (this.onNonLinearReady) {
+    this.player.off('adplaying', this.onNonLinearReady);
+    this.player.off('playing', this.onNonLinearReady);
+    this.onNonLinearReady = null;
+  }
+  if (this.onCompanionReady) {
+    this.player.off('adplaying', this.onCompanionReady);
+    this.player.off('playing', this.onCompanionReady);
+    this.onCompanionReady = null;
+  }
+}
+
+export function removeEventsListeners() {
+  this.debug('removeEventsListeners');
+  this.cleanupReadAdListeners();
+  this.player.off('adplaying', this.onFirstPlay);
+  playerEvents.forEach(({ event, handler }) => {
+    this.player.off(event, this[handler]);
+  });
+  // added only if some midrolls have been found, remove by security
+  this.player.off('timeupdate', this.onProgress);
+  window.removeEventListener('beforeunload', this.onUnload);
+}

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import videojs from 'video.js';
 import 'videojs-contrib-ads';
 import { VASTClient, VASTTracker, VASTParser } from '@dailymotion/vast-client';
 import { addIcons } from './features/icons';
+import { addEventsListeners, removeEventsListeners, cleanupReadAdListeners } from './features/eventManager';
 import { playLinearAd } from './modes/linear';
 import { playCompanionAd } from './modes/companions';
 import { playNonLinearAd } from './modes/nonlinear';
@@ -272,20 +273,22 @@ class Vast extends Plugin {
       return null;
     }
     const nextAd = this.adsArray.shift();
+    const linear = nextAd.creatives.find((c) => c.type === 'linear');
+    const companion = nextAd.creatives.find((c) => c.type === 'companion');
+    const nonlinear = nextAd.creatives.find((c) => c.type === 'nonlinear');
+
+    const hasValidLinear = linear
+      && linear.mediaFiles.length > 0
+      && linear.mediaFiles.some((mf) => mf.fileURL !== '');
+
     return {
       ad: nextAd,
-      hasLinearCreative: () => {
-        // find linear content
-        const linear = nextAd.creatives.find((creative) => creative.type === 'linear') !== undefined && nextAd.creatives.filter((creative) => creative.type === 'linear')[0];
-        // check if at least one mediaFile is provided
-        const hasMediaFile = linear.mediaFiles.length > 0 && linear.mediaFiles.some((mediaFile) => mediaFile.fileURL !== '');
-        return linear && hasMediaFile;
-      },
-      linearCreative: () => nextAd.creatives.filter((creative) => creative.type === 'linear')[0],
-      hasCompanionCreative: () => nextAd.creatives.find((creative) => creative.type === 'companion') !== undefined,
-      companionCreative: () => nextAd.creatives.filter((creative) => creative.type === 'companion')[0],
-      hasNonlinearCreative: () => nextAd.creatives.find((creative) => creative.type === 'nonlinear') !== undefined,
-      nonlinearCreative: () => nextAd.creatives.filter((creative) => creative.type === 'nonlinear')[0],
+      hasLinearCreative: () => !!hasValidLinear,
+      linearCreative: () => linear,
+      hasCompanionCreative: () => !!companion,
+      companionCreative: () => companion,
+      hasNonlinearCreative: () => !!nonlinear,
+      nonlinearCreative: () => nonlinear,
     };
   }
 
@@ -343,30 +346,27 @@ class Vast extends Plugin {
   onAdVolumeChange = () => {
     this.debug('volume');
     if (!this.linearVastTracker) {
-      return false;
+      return;
     }
     // Track the user muting or unmuting the video
     this.linearVastTracker.setMuted(this.player.muted(), {
       ...this.macros,
       ADPLAYHEAD: this.linearVastTracker.convertToTimecode(this.player.currentTime()),
     });
-    return true;
   };
 
   onAdFullScreen = (evt, data) => {
     this.debug('fullscreen');
     if (!this.linearVastTracker) {
-      return false;
+      return;
     }
-    // Track skip event
     this.linearVastTracker.setFullscreen(data.state);
-    return true;
   };
 
   // Track when user closes the video
   onUnload = () => {
     if (!this.linearVastTracker) {
-      return false;
+      return;
     }
 
     this.linearVastTracker.close({
@@ -374,7 +374,6 @@ class Vast extends Plugin {
       ADPLAYHEAD: this.linearVastTracker.convertToTimecode(this.player.currentTime()),
     });
     this.removeEventsListeners();
-    return null;
   };
 
   // Notify the player if we reach a timeout while trying to load the ad
@@ -401,7 +400,7 @@ class Vast extends Plugin {
     this.player.trigger('vast.play', {
       ctaUrl: this.ctaUrl,
       skipDelay: this.linearVastTracker?.skipDelay,
-      adClickCallback: this.ctaUrl ? () => this.adClickCallback(this.ctaUrl) : false,
+      adClickCallback: this.ctaUrl ? () => this.adClickCallback(this.ctaUrl) : null,
       duration: this.player.duration(),
     });
     // Track the impression of an ad
@@ -592,62 +591,6 @@ class Vast extends Plugin {
     }
   }
 
-  addEventsListeners() {
-    // ad events
-    this.player.one('adplaying', this.onFirstPlay);
-    this.player.on('adplaying', this.onAdPlay);
-    this.player.on('adpause', this.onAdPause);
-    this.player.on('adtimeupdate', this.onAdTimeUpdate);
-    this.player.on('advolumechange', this.onAdVolumeChange);
-    this.player.on('adfullscreen', this.onAdFullScreen);
-    this.player.on('adtimeout', this.onAdTimeout);
-    this.player.on('adstart', this.onAdStart);
-    this.player.on('aderror', this.onAdError);
-    this.player.on('readyforpreroll', this.onReadyForPreroll);
-    this.player.on('readyforpostroll', this.onReadyForPostroll);
-    this.player.on('skip', this.onSkip);
-    this.player.on('adended', this.onAdEnded);
-    this.player.on('ended', this.onEnded);
-    this.player.on('dispose', this.onDispose);
-    window.addEventListener('beforeunload', this.onUnload);
-  }
-
-  cleanupReadAdListeners() {
-    if (this.onNonLinearReady) {
-      this.player.off('adplaying', this.onNonLinearReady);
-      this.player.off('playing', this.onNonLinearReady);
-      this.onNonLinearReady = null;
-    }
-    if (this.onCompanionReady) {
-      this.player.off('adplaying', this.onCompanionReady);
-      this.player.off('playing', this.onCompanionReady);
-      this.onCompanionReady = null;
-    }
-  }
-
-  removeEventsListeners() {
-    this.debug('removeEventsListeners');
-    this.cleanupReadAdListeners();
-    this.player.off('adplaying', this.onAdPlay);
-    this.player.off('adplaying', this.onFirstPlay);
-    this.player.off('adpause', this.onAdPause);
-    this.player.off('adtimeupdate', this.onAdTimeUpdate);
-    this.player.off('advolumechange', this.onAdVolumeChange);
-    this.player.off('adfullscreen', this.onAdFullScreen);
-    this.player.off('adtimeout', this.onAdTimeout);
-    this.player.off('adstart', this.onAdStart);
-    this.player.off('aderror', this.onAdError);
-    // added only if some midrolls have been found, remove by security
-    this.player.off('timeupdate', this.onProgress);
-    this.player.off('readyforpreroll', this.onReadyForPreroll);
-    this.player.off('readyforpostroll', this.onReadyForPostroll);
-    this.player.off('skip', this.onSkip);
-    this.player.off('adended', this.onAdEnded);
-    this.player.off('ended', this.onEnded);
-    this.player.off('dispose', this.onDispose);
-    window.removeEventListener('beforeunload', this.onUnload);
-  }
-
   /*
   * This method is responsible for dealing with the click on the ad
   */
@@ -749,6 +692,9 @@ Vast.prototype.playLinearAd = playLinearAd;
 Vast.prototype.playNonLinearAd = playNonLinearAd;
 Vast.prototype.playCompanionAd = playCompanionAd;
 Vast.prototype.addIcons = addIcons;
+Vast.prototype.addEventsListeners = addEventsListeners;
+Vast.prototype.removeEventsListeners = removeEventsListeners;
+Vast.prototype.cleanupReadAdListeners = cleanupReadAdListeners;
 
 export default Vast;
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -47,7 +47,7 @@ export const convertTimeOffsetToSeconds = (timecode, duration = null) => {
   }
   // convert timeoffset in seconds from the start
   if (timecode.includes('#')) {
-    return timecode.replace('#', '');
+    return Number(timecode.replace('#', ''));
   }
   // convert timeoffset in timecode
   const [time, ms] = timecode.split('.');
@@ -118,7 +118,7 @@ export const getBestCtaUrl = (creative) => {
     && creative.videoClickThroughURLTemplate.url) {
     return creative.videoClickThroughURLTemplate.url;
   }
-  return false;
+  return null;
 };
 
 export const getMidrolls = (adBreaks) => {
@@ -140,14 +140,27 @@ export const getMidrolls = (adBreaks) => {
 
 export const getPreroll = (adBreaks) => {
   if (adBreaks) {
-    return adBreaks.filter((adBreak) => ['start', '0%', '00:00:00'].includes(adBreak.timeOffset))[0];
+    return adBreaks.find((adBreak) => ['start', '0%', '00:00:00'].includes(adBreak.timeOffset)) ?? null;
   }
-  return false;
+  return null;
+};
+
+export const appendToSlotOrPlayer = (element, adSlotID, playerEl) => {
+  if (adSlotID) {
+    const adSlot = document.querySelector(`#${adSlotID}`);
+    if (adSlot) {
+      adSlot.appendChild(element);
+    } else {
+      console.warn(`VastVjs: adSlotID #${adSlotID} not found in DOM`);
+    }
+  } else {
+    playerEl.appendChild(element);
+  }
 };
 
 export const getPostroll = (adBreaks) => {
   if (adBreaks) {
-    return adBreaks.filter((adBreak) => ['end', '100%'].includes(adBreak.timeOffset))[0];
+    return adBreaks.find((adBreak) => ['end', '100%'].includes(adBreak.timeOffset)) ?? null;
   }
-  return false;
+  return null;
 };

--- a/src/lib/utils.test.js
+++ b/src/lib/utils.test.js
@@ -60,7 +60,7 @@ describe('convertTimeOffsetToSeconds', () => {
 
   it('converts hash-prefixed seconds', () => {
     const result = convertTimeOffsetToSeconds('#45');
-    expect(result).toBe('45');
+    expect(result).toBe(45);
   });
 
   it('converts HH:MM:SS timecode', () => {
@@ -89,12 +89,12 @@ describe('getBestCtaUrl', () => {
 
   it('returns false when no template exists', () => {
     const creative = {};
-    expect(getBestCtaUrl(creative)).toBe(false);
+    expect(getBestCtaUrl(creative)).toBeNull();
   });
 
   it('returns false when template has no url', () => {
     const creative = { videoClickThroughURLTemplate: {} };
-    expect(getBestCtaUrl(creative)).toBe(false);
+    expect(getBestCtaUrl(creative)).toBeNull();
   });
 });
 
@@ -142,8 +142,8 @@ describe('getPreroll', () => {
   const makeAdBreak = (timeOffset) => ({ timeOffset });
 
   it('returns false when no adBreaks', () => {
-    expect(getPreroll(null)).toBe(false);
-    expect(getPreroll(undefined)).toBe(false);
+    expect(getPreroll(null)).toBeNull();
+    expect(getPreroll(undefined)).toBeNull();
   });
 
   it('finds preroll with "start" offset', () => {
@@ -161,9 +161,9 @@ describe('getPreroll', () => {
     expect(getPreroll(adBreaks)).toEqual({ timeOffset: '00:00:00' });
   });
 
-  it('returns undefined when no preroll found', () => {
+  it('returns null when no preroll found', () => {
     const adBreaks = [makeAdBreak('00:01:00')];
-    expect(getPreroll(adBreaks)).toBeUndefined();
+    expect(getPreroll(adBreaks)).toBeNull();
   });
 });
 
@@ -171,8 +171,8 @@ describe('getPostroll', () => {
   const makeAdBreak = (timeOffset) => ({ timeOffset });
 
   it('returns false when no adBreaks', () => {
-    expect(getPostroll(null)).toBe(false);
-    expect(getPostroll(undefined)).toBe(false);
+    expect(getPostroll(null)).toBeNull();
+    expect(getPostroll(undefined)).toBeNull();
   });
 
   it('finds postroll with "end" offset', () => {
@@ -185,8 +185,8 @@ describe('getPostroll', () => {
     expect(getPostroll(adBreaks)).toEqual({ timeOffset: '100%' });
   });
 
-  it('returns undefined when no postroll found', () => {
+  it('returns null when no postroll found', () => {
     const adBreaks = [makeAdBreak('00:01:00')];
-    expect(getPostroll(adBreaks)).toBeUndefined();
+    expect(getPostroll(adBreaks)).toBeNull();
   });
 });

--- a/src/modes/companions.js
+++ b/src/modes/companions.js
@@ -1,42 +1,34 @@
-/* eslint-disable max-len */
-import { applyNonLinearCommonDomStyle, sanitizeHtml } from '../lib/utils';
+import { applyNonLinearCommonDomStyle, sanitizeHtml, appendToSlotOrPlayer } from '../lib/utils';
 
 /*
-* This method is responsible for rendering a nonlinear ad
+* This method is responsible for rendering a companion ad
 */
 export function playCompanionAd(creative) {
   creative.variations.forEach((variation) => {
     this.companionVastTracker.trackImpression(this.macros);
+
+    const clickHandler = () => {
+      window.open(variation.companionClickThroughURLTemplate, '_blank');
+      this.companionVastTracker.click(null, this.macros);
+    };
 
     // image
     if (variation.staticResources && variation.staticResources.length > 0) {
       variation.staticResources.forEach((staticResource) => {
         const resourceContainer = document.createElement('div');
         this.domElements.push(resourceContainer);
-        resourceContainer.width = variation.staticResources.width > 0 ? variation.staticResources.width : 100;
-        resourceContainer.height = variation.staticResources.height > 0 ? variation.staticResources.height : 100;
+        const { width, height } = variation.staticResources;
+        resourceContainer.width = width > 0 ? width : 100;
+        resourceContainer.height = height > 0 ? height : 100;
         resourceContainer.style.maxWidth = variation.staticResources.expandedWidth;
         resourceContainer.style.maxHeight = variation.staticResources.expandedHeight;
         applyNonLinearCommonDomStyle(resourceContainer);
 
         const resource = document.createElement('img');
-        this.domElements.push(resourceContainer);
-        resource.addEventListener('click', () => {
-          window.open(variation.companionClickThroughURLTemplate, '_blank');
-          this.companionVastTracker.click(null, this.macros);
-        });
+        resource.addEventListener('click', clickHandler);
         resource.src = staticResource.url;
         resourceContainer.appendChild(resource);
-        if (variation.adSlotID) {
-          const adSlot = document.querySelector(`#${variation.adSlotID}`);
-          if (adSlot) {
-            adSlot.appendChild(resourceContainer);
-          } else {
-            console.warn(`VastVjs: adSlotID #${variation.adSlotID} not found in DOM`);
-          }
-        } else {
-          this.player.el().appendChild(resourceContainer);
-        }
+        appendToSlotOrPlayer(resourceContainer, variation.adSlotID, this.player.el());
       });
     }
 
@@ -50,21 +42,9 @@ export function playCompanionAd(creative) {
         resourceContainer.style.maxWidth = variation.htmlResources.expandedWidth;
         resourceContainer.style.maxHeight = variation.htmlResources.expandedHeight;
         applyNonLinearCommonDomStyle(resourceContainer);
-        resourceContainer.addEventListener('click', () => {
-          window.open(variation.companionClickThroughURLTemplate, '_blank');
-          this.companionVastTracker.click(null, this.macros);
-        });
+        resourceContainer.addEventListener('click', clickHandler);
         resourceContainer.innerHTML = sanitizeHtml(htmlResource);
-        if (variation.adSlotID) {
-          const adSlot = document.querySelector(`#${variation.adSlotID}`);
-          if (adSlot) {
-            adSlot.appendChild(resourceContainer);
-          } else {
-            console.warn(`VastVjs: adSlotID #${variation.adSlotID} not found in DOM`);
-          }
-        } else {
-          this.player.el().appendChild(resourceContainer);
-        }
+        appendToSlotOrPlayer(resourceContainer, variation.adSlotID, this.player.el());
       });
     }
 
@@ -78,21 +58,9 @@ export function playCompanionAd(creative) {
         resourceContainer.style.maxWidth = variation.iframeResources.expandedWidth;
         resourceContainer.style.maxHeight = variation.iframeResources.expandedHeight;
         applyNonLinearCommonDomStyle(resourceContainer);
-        resourceContainer.addEventListener('click', () => {
-          window.open(variation.companionClickThroughURLTemplate, '_blank');
-          this.companionVastTracker.click(null, this.macros);
-        });
+        resourceContainer.addEventListener('click', clickHandler);
         resourceContainer.src = iframeResource;
-        if (variation.adSlotID) {
-          const adSlot = document.querySelector(`#${variation.adSlotID}`);
-          if (adSlot) {
-            adSlot.appendChild(resourceContainer);
-          } else {
-            console.warn(`VastVjs: adSlotID #${variation.adSlotID} not found in DOM`);
-          }
-        } else {
-          this.player.el().appendChild(resourceContainer);
-        }
+        appendToSlotOrPlayer(resourceContainer, variation.adSlotID, this.player.el());
       });
     }
   });

--- a/src/modes/nonlinear.js
+++ b/src/modes/nonlinear.js
@@ -1,4 +1,6 @@
-import { applyNonLinearCommonDomStyle, getCloseButton, sanitizeHtml } from '../lib/utils';
+import {
+  applyNonLinearCommonDomStyle, getCloseButton, sanitizeHtml, appendToSlotOrPlayer,
+} from '../lib/utils';
 
 /*
 * This method is responsible for rendering a nonlinear ad
@@ -7,6 +9,11 @@ export function playNonLinearAd(creative) {
   creative.variations.forEach((variation) => {
     this.nonLinearVastTracker.trackImpression(this.macros);
 
+    const clickHandler = () => {
+      window.open(variation.nonlinearClickThroughURLTemplate, '_blank');
+      this.nonLinearVastTracker.click(null, this.macros);
+    };
+
     // image
     if (variation.staticResource) {
       const resourceContainer = document.createElement('div');
@@ -14,10 +21,7 @@ export function playNonLinearAd(creative) {
       applyNonLinearCommonDomStyle(resourceContainer);
 
       const resource = document.createElement('img');
-      resource.addEventListener('click', () => {
-        window.open(variation.nonlinearClickThroughURLTemplate, '_blank');
-        this.nonLinearVastTracker.click(null, this.macros);
-      });
+      resource.addEventListener('click', clickHandler);
       resourceContainer.style.maxWidth = variation.expandedWidth;
       resourceContainer.style.maxHeight = variation.expandedHeight;
       resource.src = variation.staticResource;
@@ -33,16 +37,7 @@ export function playNonLinearAd(creative) {
         }, variation.minSuggestedDuration * 1000);
       }
       resourceContainer.appendChild(resource);
-      if (variation.adSlotID) {
-        const adSlot = document.querySelector(`#${variation.adSlotID}`);
-        if (adSlot) {
-          adSlot.appendChild(resourceContainer);
-        } else {
-          console.warn(`VastVjs: adSlotID #${variation.adSlotID} not found in DOM`);
-        }
-      } else {
-        this.player.el().appendChild(resourceContainer);
-      }
+      appendToSlotOrPlayer(resourceContainer, variation.adSlotID, this.player.el());
     }
 
     // html
@@ -50,25 +45,13 @@ export function playNonLinearAd(creative) {
       const resourceContainer = document.createElement('div');
       this.domElements.push(resourceContainer);
       applyNonLinearCommonDomStyle(resourceContainer);
-      resourceContainer.addEventListener('click', () => {
-        window.open(variation.nonlinearClickThroughURLTemplate, '_blank');
-        this.nonLinearVastTracker.click(null, this.macros);
-      });
+      resourceContainer.addEventListener('click', clickHandler);
 
       resourceContainer.style.maxWidth = variation.expandedWidth;
       resourceContainer.style.maxHeight = variation.expandedHeight;
       resourceContainer.innerHTML = sanitizeHtml(variation.htmlResource);
 
-      if (variation.adSlotID) {
-        const adSlot = document.querySelector(`#${variation.adSlotID}`);
-        if (adSlot) {
-          adSlot.appendChild(resourceContainer);
-        } else {
-          console.warn(`VastVjs: adSlotID #${variation.adSlotID} not found in DOM`);
-        }
-      } else {
-        this.player.el().appendChild(resourceContainer);
-      }
+      appendToSlotOrPlayer(resourceContainer, variation.adSlotID, this.player.el());
       if (variation.minSuggestedDuration) {
         setTimeout(() => {
           resourceContainer.remove();
@@ -81,25 +64,13 @@ export function playNonLinearAd(creative) {
       const resourceContainer = document.createElement('iframe');
       this.domElements.push(resourceContainer);
       applyNonLinearCommonDomStyle(resourceContainer);
-      resourceContainer.addEventListener('click', () => {
-        window.open(variation.nonlinearClickThroughURLTemplate, '_blank');
-        this.nonLinearVastTracker.click(null, this.macros);
-      });
+      resourceContainer.addEventListener('click', clickHandler);
 
       resourceContainer.style.maxWidth = variation.expandedWidth;
       resourceContainer.style.maxHeight = variation.expandedHeight;
 
       resourceContainer.src = variation.iframeResource;
-      if (variation.adSlotID) {
-        const adSlot = document.querySelector(`#${variation.adSlotID}`);
-        if (adSlot) {
-          adSlot.appendChild(resourceContainer);
-        } else {
-          console.warn(`VastVjs: adSlotID #${variation.adSlotID} not found in DOM`);
-        }
-      } else {
-        this.player.el().appendChild(resourceContainer);
-      }
+      appendToSlotOrPlayer(resourceContainer, variation.adSlotID, this.player.el());
       if (variation.minSuggestedDuration) {
         setTimeout(() => {
           resourceContainer.remove();


### PR DESCRIPTION
## Summary
- **Fix bug**: `convertTimeOffsetToSeconds('#45')` returned string `'45'` instead of number `45`
- **Deduplicate**: Extract `appendToSlotOrPlayer()` to remove 6 duplicate adSlotID blocks in nonlinear/companions
- **Refactor `getNextAd()`**: Compute creatives once with `find()` instead of redundant `find()`+`filter()` on every call
- **Harmonize returns**: Replace `false` with `null` for `getBestCtaUrl`, `getPreroll`, `getPostroll`; remove useless return values in event handlers
- **Extract event manager**: Declarative event list in `eventManager.js` — no more risk of asymmetric add/remove

## Test plan
- [x] Unit tests pass (28/28)
- [x] ESLint clean
- [x] Build (CJS + ESM) succeeds
- [ ] E2E tests (Cypress) to validate on CI