### PR TITLE
VAST-84: Fix race condition in async initialization

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,21 +71,18 @@ class Vast extends Plugin {
       console.error(e);
     }
 
-    const self = this;
     if (options.vmapUrl) {
-      self.handleVMAP(options.vmapUrl);
+      this.handleVMAP(options.vmapUrl);
     } else {
-      self.disablePostroll();
-      (async () => {
-        await self.handleVAST(options.vastUrl, () => {
-          self.disablePreroll();
-        });
-        if (self.adsArray.length > 0) {
-          self.addEventsListeners();
-          // has to be done outside of handleVAST because not done at the same moment for VMAP case
-          self.player.trigger('adsready');
+      this.disablePostroll();
+      this.addEventsListeners();
+      this.handleVAST(options.vastUrl, () => {
+        this.disablePreroll();
+      }).then(() => {
+        if (this.adsArray.length > 0) {
+          this.player.trigger('adsready');
         }
-      })();
+      });
     }
   }
 


### PR DESCRIPTION
## Summary
- Remove `const self = this` pattern (workaround for Turbopack bundling issue, VAST-72)
- Replace async IIFE with `.then()` to preserve lexical `this` in class context
- Register event listeners **before** async VAST fetch to prevent race condition where `readyforpreroll` could fire before listeners were attached
- Aligns VAST path with VMAP path which already registered listeners first

## Context
Under Turbopack, `this` was lost inside the async IIFE (VAST-72). The `const self = this` workaround fixed that but masked a deeper issue: `addEventsListeners()` was called **after** the async fetch, meaning events emitted during the fetch were missed (VAST-84). This was also related to PLAYER-3648 where plugin re-instantiation caused tracking failures.

## Test plan
- [x] Unit tests pass (28/28)
- [x] ESLint clean
- [x] Build (CJS + ESM) succeeds
- [ ] E2E tests on CI
- [ ] Manual validation with ARTE Video Player (sensitive: SST tracking)