### PR TITLE
chore: add CLAUDE.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ build/
 /**/coverage/
 node_modules
 cypress/screenshots/*
+CLAUDE.md


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` to `.gitignore` so the local Claude Code configuration file is never committed accidentally