### PR TITLE
fix: align package scope with GitHub org (@artegeie)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-@artegie:registry=https://npm.pkg.github.com
+@artegeie:registry=https://npm.pkg.github.com

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Changed
 
-- **VAST-73:** Migrate package from NPM to GitHub Packages (`@artegie/videojs-vast`)
+- **VAST-73:** Migrate package from NPM to GitHub Packages (`@artegeie/videojs-vast`)
 - Add GitHub Actions workflow for automated publishing on tag push
 
 ## [1.5.4](https://github.com/ArteGEIE/videojs-vast/compare/1.5.3...1.5.4) (2026-02-06)

--- a/README.md
+++ b/README.md
@@ -30,17 +30,17 @@ Table of contents
 
 In order to start using the VAST Plugin you are supposed to have started a project that consumes VideosJS and have some basic knowledge of its basic concepts and API. To get started, install and include this package in your project's dependencies using npm or yarn:
 
-First, configure your `.npmrc` to use GitHub Packages for the `@artegie` scope:
+First, configure your `.npmrc` to use GitHub Packages for the `@artegeie` scope:
 
 ```
-@artegie:registry=https://npm.pkg.github.com
+@artegeie:registry=https://npm.pkg.github.com
 ```
 
 Then install the package:
 
 ```
-npm install --save @artegie/videojs-vast
-yarn add @artegie/videojs-vast
+npm install --save @artegeie/videojs-vast
+yarn add @artegeie/videojs-vast
 ```
 
 Now, import the plugin package and initialize it right after initializing your VideoJS instance. Here's a small snipet that of what it could look like:
@@ -48,7 +48,7 @@ Now, import the plugin package and initialize it right after initializing your V
 ```
 // Import the necessary packages
 import videojs from 'video.js';
-import '@artegie/videojs-vast';
+import '@artegeie/videojs-vast';
 
 // Create VideoJS instance
 const videoJsInstance = videojs('my-player', {
@@ -145,7 +145,7 @@ If you prefer using [**yalc**](https://www.npmjs.com/package/yalc) to test the p
 
 * Install Yalc globally with ```npm i yalc -g```
 * Run ```npm run build:local``` to build and push to the local yalc registry
-* In your project, run ```yalc add @artegie/videojs-vast```
+* In your project, run ```yalc add @artegeie/videojs-vast```
 
 #### Testing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@artegie/videojs-vast",
+  "name": "@artegeie/videojs-vast",
   "version": "1.5.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@artegie/videojs-vast",
+      "name": "@artegeie/videojs-vast",
       "version": "1.5.4",
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@artegie/videojs-vast",
+  "name": "@artegeie/videojs-vast",
   "version": "1.5.4",
   "main": "./dist/cjs/index.js",
   "module": "./dist/mjs/index.js",


### PR DESCRIPTION
## Summary

- Fix npm scope from `@artegie` to `@artegeie` to match GitHub org `ArteGEIE`
- GitHub Packages requires the npm scope to match the repository owner (lowercased)
- Without this fix, `npm publish` to GitHub Packages would fail

## Files changed

- `package.json` — package name
- `package-lock.json` — lockfile regenerated
- `.npmrc` — registry scope
- `README.md` — installation instructions
- `CHANGELOG.md` — migration note

## Next steps

After merge:
1. `npm run release` (bumps version, changelog, git tag)
2. `git push --follow-tags` → triggers publish workflow