### PR TITLE
feat: forward preroll media URL in vast.play payload (PLAYER-3664)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.7.0](https://github.com/ArteGEIE/videojs-vast/compare/v1.6.0...v1.7.0) (2026-06-11)
+
+### Changed
+
+- **PLAYER-3664:** Forward the preroll media URL (`streamUrl`) in the `vast.play` event payload, consumed by arteVp SST for the `AD_STARTED` event
+
 ## [1.6.0](https://github.com/ArteGEIE/videojs-vast/compare/1.5.4...v1.6.0) (2026-03-03)
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@artegeie/videojs-vast",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@artegeie/videojs-vast",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@dailymotion/vast-client": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artegeie/videojs-vast",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "main": "./dist/cjs/index.js",
   "module": "./dist/mjs/index.js",
   "license": "Apache-2.0",

--- a/src/index.js
+++ b/src/index.js
@@ -399,6 +399,8 @@ class Vast extends Plugin {
       skipDelay: this.linearVastTracker?.skipDelay,
       adClickCallback: this.ctaUrl ? () => this.adClickCallback(this.ctaUrl) : null,
       duration: this.player.duration(),
+      // preroll media URL, consumed by arteVp SST for the AD_STARTED event (PLAYER-3664)
+      streamUrl: this.currentAdStreamUrl,
     });
     // Track the impression of an ad
     this.linearVastTracker?.load({

--- a/src/modes/linear.js
+++ b/src/modes/linear.js
@@ -7,6 +7,9 @@ export function playLinearAd(creative) {
   // Retrieve the media file from the VAST manifest
   const mediaFile = getBestMediaFile(creative.mediaFiles);
 
+  // store the preroll URL before startLinearAdMode (which triggers adstart synchronously)
+  this.currentAdStreamUrl = mediaFile.fileURL;
+
   // Start ad mode
   if (!this.player.ads.inAdBreak()) {
     this.player.ads.startLinearAdMode();


### PR DESCRIPTION
## Contexte

PLAYER-3664 : ajouter un event `AD_STARTED` dans le plan de marquage SST côté arteVp, dont le `frontendContext.player.streamUrl` doit contenir l'URL du **preroll** (pas du contenu).

## Changement

videojs-vast ne transmettait pas l'URL du média publicitaire dans son event `vast.play`. Ce PR l'ajoute :

- `src/modes/linear.js` : capture de `mediaFile.fileURL` dans `this.currentAdStreamUrl` **avant** `startLinearAdMode()` (qui déclenche `adstart` de façon synchrone), pour garantir que la valeur est disponible quand `onAdStart` se déclenche.
- `src/index.js` : ajout de `streamUrl: this.currentAdStreamUrl` au payload `vast.play`.

Rétrocompatible (ajout d'un champ optionnel). Consommé côté arteVp par le plugin SST.

## Validation

Testé en runtime via stream-tester : l'event `AD_STARTED` remonte bien `streamUrl` = URL du média VAST.