### PR TITLE
fix: emit vast.play (AD_STARTED) on real ad start instead of adstart (VAST-90)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -290,15 +290,39 @@ class Vast extends Plugin {
   }
 
   onAdPlay = () => {
+    this.handleAdPlay();
+  };
+
+  // Extracted as a prototype method so it can be unit-tested without a full plugin instance.
+  // currentTime > 0 is a resume after pause; currentTime ~0 is the real start of the ad,
+  // where we notify the consumer (AD_STARTED) and remove the loading spinner.
+  handleAdPlay() {
     this.debug('adplay');
-    // don't track the very first play to avoid sending resume tracker event
     if (parseInt(this.player.currentTime(), 10) > 0) {
+      // resume after pause, don't re-notify the ad start
       this.linearVastTracker?.setPaused(false, {
         ...this.macros,
         ADPLAYHEAD: this.linearVastTracker?.convertToTimecode(this.player.currentTime()),
       });
+    } else {
+      this.notifyAdStarted();
     }
-  };
+  }
+
+  // Notify the player consumer that the ad actually started playing.
+  // Bound to real playback (adplaying) rather than ad-mode entry (adstart) so the event
+  // fires at the true ad start even when the browser blocks autoplay (Firefox).
+  // Consumed by arteVp SST for the AD_STARTED event (PLAYER-3664) and to remove the spinner.
+  notifyAdStarted() {
+    this.player.trigger('vast.play', {
+      ctaUrl: this.ctaUrl,
+      skipDelay: this.linearVastTracker?.skipDelay,
+      adClickCallback: this.ctaUrl ? () => this.adClickCallback(this.ctaUrl) : null,
+      duration: this.player.duration(),
+      // preroll media URL, consumed by arteVp SST for the AD_STARTED event (PLAYER-3664)
+      streamUrl: this.currentAdStreamUrl,
+    });
+  }
 
   onAdPause = () => {
     this.debug('adpause');
@@ -390,18 +414,11 @@ class Vast extends Plugin {
     this.removeEventsListeners();
   };
 
-  // send event when ad is playing to remove loading spinner
+  // 'adstart' fires when the player enters ad mode (preparation), which can happen
+  // long before playback when autoplay is blocked (Firefox). The consumer-facing
+  // vast.play notification is emitted from onAdPlay instead, on the real ad start.
   onAdStart = () => {
     this.debug('adstart');
-    // Trigger an event to notify the player consumer that the ad is playing
-    this.player.trigger('vast.play', {
-      ctaUrl: this.ctaUrl,
-      skipDelay: this.linearVastTracker?.skipDelay,
-      adClickCallback: this.ctaUrl ? () => this.adClickCallback(this.ctaUrl) : null,
-      duration: this.player.duration(),
-      // preroll media URL, consumed by arteVp SST for the AD_STARTED event (PLAYER-3664)
-      streamUrl: this.currentAdStreamUrl,
-    });
     // Track the impression of an ad
     this.linearVastTracker?.load({
       ...this.macros,

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,0 +1,81 @@
+import {
+  describe, it, expect, vi,
+} from 'vitest';
+
+// video.js (and its plugin registration) is mocked so index.js can be imported in a
+// node environment without a real player. We only exercise the prototype methods.
+vi.mock('video.js', () => {
+  // base "plugin" must be a constructor (Vast extends it); never instantiated here
+  function Plugin() {}
+  const videojs = Object.assign(() => {}, {
+    getPlugin: () => Plugin,
+    registerPlugin: () => {},
+    plugin: () => {},
+  });
+  return { default: videojs };
+});
+vi.mock('videojs-contrib-ads', () => ({ default: {} }));
+vi.mock('@dailymotion/vast-client', () => ({
+  VASTClient: () => {},
+  VASTParser: () => {},
+  VASTTracker: () => {},
+}));
+
+const Vast = (await import('./index')).default;
+
+function createContext({ currentTime = 0 } = {}) {
+  const trigger = vi.fn();
+  const setPaused = vi.fn();
+  const ctx = {
+    debug: vi.fn(),
+    ctaUrl: 'https://cta.example.com',
+    currentAdStreamUrl: 'https://ads.example.com/preroll.mp4',
+    adClickCallback: vi.fn(),
+    macros: {},
+    notifyAdStarted: vi.fn(),
+    linearVastTracker: {
+      skipDelay: 5,
+      setPaused,
+      convertToTimecode: (t) => t,
+    },
+    player: {
+      trigger,
+      duration: () => 12,
+      currentTime: () => currentTime,
+    },
+  };
+  return { ctx, trigger, setPaused };
+}
+
+describe('notifyAdStarted', () => {
+  it('triggers vast.play with the preroll streamUrl and ad metadata', () => {
+    const { ctx, trigger } = createContext();
+    Vast.prototype.notifyAdStarted.call(ctx);
+    expect(trigger).toHaveBeenCalledTimes(1);
+    expect(trigger).toHaveBeenCalledWith(
+      'vast.play',
+      expect.objectContaining({
+        streamUrl: 'https://ads.example.com/preroll.mp4',
+        duration: 12,
+        skipDelay: 5,
+        ctaUrl: 'https://cta.example.com',
+      }),
+    );
+  });
+});
+
+describe('handleAdPlay', () => {
+  it('notifies the ad start on the real first play (currentTime ~0)', () => {
+    const { ctx, setPaused } = createContext({ currentTime: 0 });
+    Vast.prototype.handleAdPlay.call(ctx);
+    expect(ctx.notifyAdStarted).toHaveBeenCalledTimes(1);
+    expect(setPaused).not.toHaveBeenCalled();
+  });
+
+  it('does not re-notify on resume (currentTime > 0) but tracks the resume', () => {
+    const { ctx, setPaused } = createContext({ currentTime: 10 });
+    Vast.prototype.handleAdPlay.call(ctx);
+    expect(ctx.notifyAdStarted).not.toHaveBeenCalled();
+    expect(setPaused).toHaveBeenCalledWith(false, expect.anything());
+  });
+});


### PR DESCRIPTION
## Contexte (VAST-90)

Découvert au test de la feature AD_STARTED (PLAYER-3664) sur le feature deploy replay : sur **Firefox**, l'event `AD_STARTED` partait à l'initialisation du player, pas au démarrage réel du preroll.

## Cause

`vast.play` (consommé par arteVp pour `AD_STARTED` + retrait du spinner) était émis dans `onAdStart`, lié à l'event **`adstart`** = entrée en mode pub (préparation). Quand l'autoplay est bloqué (Firefox), `adstart` survient à l'init alors que la lecture réelle est différée. Chrome (autoplay muet autorisé) masquait le problème.

## Correctif

- `onAdStart` : suppression du trigger `vast.play` (ne reste que le tracking d'impression + UI).
- `onAdPlay` → `handleAdPlay()` : sur le **premier play réel** de chaque pub (`currentTime ≈ 0`) → `notifyAdStarted()` ; sur resume (`currentTime > 0`) → tracking resume inchangé. Gère préroll **et** midroll/postroll (une notif par pub).
- `notifyAdStarted()` : émet `vast.play` (payload identique).

## Tests

`src/index.test.js` (3 tests, video.js mocké) : payload de `notifyAdStarted` + branche start/resume de `handleAdPlay`. Suite complète : 31 tests OK, ESLint clean.

## Connexe

VAST-91 : le beacon d'impression VAST (`linearVastTracker.load`/`trackImpression`) a le même timing (`adstart`) — laissé hors scope (tracking pub à arbitrer avec l'équipe pub).
