### PR TITLE
build: vendor the video.js stylesheet in the demo page (VAST-89)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ cypress/screenshots/*
 CLAUDE.md
 docs/demo.js
 docs/demo.js.map
+docs/demo.css
+docs/demo.css.map

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,5 +1,5 @@
 <head>
-  <link href="https://vjs.zencdn.net/8.0.4/video-js.css" rel="stylesheet" />
+  <link href="demo.css" rel="stylesheet" />
 </head>
 
 <body>

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "ci:changelog": "conventional-changelog --preset angular --same-file --infile CHANGELOG.md",
     "lint": "eslint ./src",
     "serve": "serve -l 3333 docs",
-    "start": "concurrently \"npm run serve\" \"chokidar 'src/**/*.js' -c 'npm run bundle:demo'\" \"chokidar 'src/**/*.js' -c 'npm run build:local'\"",
+    "start": "concurrently \"npm run serve\" \"chokidar 'src/**/*.js' --initial -c 'npm run bundle:demo'\" \"chokidar 'src/**/*.js' -c 'npm run build:local'\"",
     "test": "npm run test:unit && npm run test:e2e",
     "test:unit": "vitest run",
     "test:e2e": "wait-on http://localhost:3333/ & cypress run --browser chrome",

--- a/src/demo.js
+++ b/src/demo.js
@@ -1,4 +1,5 @@
 import videojs from 'video.js';
+import 'video.js/dist/video-js.css';
 import './index';
 
 /**


### PR DESCRIPTION
## Context

VAST-89 reported the e2e job failing on every branch with `expected timeupdate to have been called at least once` on the `empty VAST` spec.

**That failure is already fixed on develop.** VAST-92 (#120) replaced the remote demo content with a local fixture, and the e2e suite passes 11/11 on develop today — verified by running it locally before touching anything. The open dependabot PRs are still red only because their branches predate that fix and have never been re-run.

What remained was the last third-party network dependency in the e2e critical path, which this PR removes.

## Changes

**Vendor the Video.js stylesheet.** `docs/index.html` pulled its stylesheet from `https://vjs.zencdn.net/8.0.4/video-js.css`. Since that page is the fixture for every Cypress spec, a CDN outage would break the whole suite: without the stylesheet, `.vjs-big-play-button` has no dimensions, and all 11 specs open with a click on it.

The stylesheet now comes from the local `video.js` devDependency. esbuild extracts it to `docs/demo.css`, exactly as it already emits `docs/demo.js` — no build script or workflow needed changing, since esbuild derives the CSS name from the `--outfile` basename.

Two side benefits:
- The CDN served a pinned **8.0.4** while `video.js` resolves to **8.3.0**. The demo was shipping a stylesheet that did not match its own JavaScript; the two are now aligned and pinned by `package-lock.json`.
- The vendored file embeds its icon font as a base64 data URI, so the demo page now loads with **zero external requests**.

**Run the demo bundler on start.** The `bundle:demo` watcher lacked `--initial`, so `npm start` emitted nothing until the first change under `src/`. On a fresh clone the page was served with no script — and, once the stylesheet became a build artifact, no styles either. The `build:local` watcher is deliberately left alone: `--initial` there would fire a `yalc push` to consuming projects on every `npm start`.

## The published package is untouched

`esbuild.js` only takes `src/index.js` as its entry, and nothing imports `src/demo.js`. `dist/cjs` and `dist/mjs` are byte-identical, so integrators keep managing their own stylesheet.

## Verification

| Check | Result |
|---|---|
| `npm run lint` | pass |
| `npm run test:unit` | 31/31 |
| Cypress e2e | 11/11 |
| Skin rendering | verified visually — play button renders at 90x49 with its icon font |
| `npm start` on a fresh clone | serves `demo.js` and `demo.css` with no change under `src/` |
| `dist/` diff vs develop | none |

## Out of scope

Two pre-existing issues surfaced during review and are deliberately left alone — no tickets created:
- The XML fixtures still reference ~125 external URLs. These are fire-and-forget tracking beacons, not blocking for any assertion.
- `npm audit` flags a **high** severity issue on `@xmldom/xmldom`, present on develop and unrelated to this PR. Worth its own ticket given this project parses third-party VAST/VMAP XML.