### PR TITLE
chore(release): 1.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## [1.7.3](https://github.com/ArteGEIE/videojs-vast/compare/v1.7.2...v1.7.3) (2026-08-21)
+
+### Changed
+
+- **VAST-89:** Vendor the Video.js stylesheet in the demo page. It was loaded from the `vjs.zencdn.net` CDN, which sat in the critical path of the Cypress e2e job since that page is its fixture. It is now bundled from the local `video.js` dependency, which also realigns it with the player version (the CDN served a pinned 8.0.4 against video.js 8.3.0)
+- **VAST-89:** Run the demo bundler on `npm start`, so a fresh clone is served with its script and styles instead of waiting for the first change under `src/`
+- **VAST-93:** Bump `@xmldom/xmldom` from 0.8.7 to 0.8.14, clearing all advisories reported by `npm audit`. The vulnerable code path (XML serialization) was never reached in this project
+- Dependency maintenance: 16 Dependabot updates merged, including `cypress`, `axios`, `@babel/core`, `vite`, `postcss` and `lodash`
+
+### Notes
+
+No functional change for integrators: `dist/cjs` and `dist/mjs` are unchanged since 1.7.2, and the declared dependencies are identical. This release covers tooling, the demo page and transitive dependency hygiene.
+
+
+
 ## [1.7.2](https://github.com/ArteGEIE/videojs-vast/compare/v1.7.1...v1.7.2) (2026-06-23)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@artegeie/videojs-vast",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@artegeie/videojs-vast",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@dailymotion/vast-client": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artegeie/videojs-vast",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "main": "./dist/cjs/index.js",
   "module": "./dist/mjs/index.js",
   "license": "Apache-2.0",


### PR DESCRIPTION
Release 1.7.3.

## Contents

Eighteen commits since 1.7.2: the VAST-89 CI hardening, the VAST-93 security bump, and sixteen Dependabot updates.

- **VAST-89** — The demo page loaded its Video.js stylesheet from `vjs.zencdn.net`. Since that page is the fixture for every Cypress spec, the CDN sat in the critical path of the e2e job. It is now vendored from the local `video.js` dependency, which also realigns the stylesheet with the player (the CDN served a pinned 8.0.4 against video.js 8.3.0). The demo bundler also runs on `npm start` now, so a fresh clone is served properly.
- **VAST-93** — `@xmldom/xmldom` 0.8.7 to 0.8.14, clearing every advisory from `npm audit`. The vulnerable path (XML serialization) was never reached here: the browser build of vast-client does not bundle xmldom, mpd-parser imports only its DOMParser, and `parseInlineVastData` uses the native `XMLSerializer`.
- **Dependency maintenance** — 16 Dependabot PRs merged, including `cypress` (15.21.0), `axios` (1.19.0), `@babel/core` (7.29.7), `vite`, `postcss` and `lodash`.

## No functional change for integrators

`dist/cjs` and `dist/mjs` are unchanged since 1.7.2, and the declared dependencies are identical. Verified: the only file under `src/` touched since v1.7.2 is `src/demo.js`, and the build entry is `./src/index.js` alone, so the demo import never reaches the published bundle.

## On the handwritten CHANGELOG entry

`ci:changelog` produces nothing here: the angular preset only surfaces `feat`/`fix`/`perf`, and all eighteen commits are `build:` or `chore:`. Since `create-gh-release` extracts the section matching the tag from `CHANGELOG.md`, an auto-generated run would have left the release with no notes, and likely failed the workflow. The entry follows the handwritten format already used for 1.7.0.

## Verification

| Check | Result |
|---|---|
| `npm run lint` | pass |
| `npm run build` | pass — dist/cjs 37K, dist/mjs 38K |
| `npm run test:unit` | 31/31 |
| Cypress e2e | 11/11 (Cypress 15.21.0) |
| `npm audit --omit=dev` | 0 vulnerabilities |

## After merge

Tag `v1.7.3` on develop and push it, which triggers `create-release` and `publish`.