### PR TITLE
build: drop safari11 from the esm target (VAST-94)

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -27,7 +27,7 @@ const configByFormat = format === 'cjs' ? {
   outExtension: { '.js': buildConfig.mjs.extension },
   format: 'esm',
   splitting: true,
-  target: ['es2020', 'safari11'],
+  target: ['es2020'],
 };
 
 const externalDeps = [


### PR DESCRIPTION
Unblocks #129 (esbuild 0.27.3 to 0.28.2), whose `lint-build-test` job fails at build time.

## The problem

`esbuild.js:30` declared a contradictory target:

```js
target: ['es2020', 'safari11']
```

Safari 11 (2017) predates ES2020. esbuild keeps the most restrictive target, so it has to downlevel destructuring for Safari 11 — and it cannot, that transform is unsupported below Safari 15. esbuild 0.27 stayed silent and emitted the code untransformed; 0.28 refuses to build:

```
[ERROR] Transforming destructuring to the configured target environment
        ("es2020", "safari11") is not supported yet
```

Measured against the failing source pattern with esbuild 0.28.2: `safari11`, `safari12` and `safari14` all fail; `safari15` and `es2020` alone build. The real threshold is Safari 15, not Safari 12.

## What safari11 actually did

Diffing both builds, the only difference is object spread: with `safari11`, esbuild emitted `__spreadValues` helpers (~2 KB); without it, native spread is used. Destructuring came out untransformed either way.

Native object spread is supported from **Safari 11.1**, and web-front declares `safari >= 12` in the browserslist of `apps/replay` and `apps/corporate`. Those helpers served no browser the product supports.

Nothing downstream compensated either: arteVp externalises this package (its bundle keeps a literal `import "@artegeie/videojs-vast";`) and web-front does not list `@artegeie/arte-vp` in `transpilePackages`.

## Verification

| Check | Result |
|---|---|
| `npm run build` with esbuild **0.28.2** | **pass** — the point of the fix |
| `npm run build` with esbuild 0.27.3 | pass |
| `npm run lint` | pass |
| `npm run test:unit` | 31/31 |
| Cypress e2e | 11/11 |
| `dist/mjs/index.js` | 38K to 36K, `__spreadValues` helpers gone |
| `dist/cjs/index.js` | unchanged — the CJS branch never had a target |

## Follow-ups

- #129 should be rebased once this lands; it is expected to turn green.
- arteVp carries the identical contradiction in `packages/arteVp/esbuild.js:40`. Tracked separately in PLAYER-3695, since it is a different project.