### PR TITLE
chore(release): 1.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## [1.7.4](https://github.com/ArteGEIE/videojs-vast/compare/v1.7.3...v1.7.4) (2026-08-26)
+
+### Changed
+
+- **VAST-94:** Drop `safari11` from the ESM build target. The target declared `['es2020', 'safari11']`, which is contradictory since Safari 11 predates ES2020. esbuild kept the most restrictive target and had to downlevel destructuring for Safari 11, which it cannot do below Safari 15: 0.27 stayed silent and emitted the code untransformed, while 0.28 fails the build outright
+- Bump `esbuild` from 0.27.3 to 0.28.2, unblocked by the target fix above
+
+### Bundle impact
+
+`dist/mjs/index.js` drops from 38 KB to 36 KB. The only removed code is the `__spreadValues` helper set, which esbuild emitted to transpile object spread for Safari 11. Native object spread is supported from Safari 11.1, and web-front targets `safari >= 12`, so no supported browser relied on those helpers. `dist/cjs/index.js` is unchanged: the CommonJS build never declared a target.
+
+Integrators supporting Safari 11.0 exactly would be affected. Note that destructuring was never transpiled for that target anyway, so the guarantee it implied was not actually produced.
+
+
+
 ## [1.7.3](https://github.com/ArteGEIE/videojs-vast/compare/v1.7.2...v1.7.3) (2026-08-21)
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@artegeie/videojs-vast",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@artegeie/videojs-vast",
-      "version": "1.7.3",
+      "version": "1.7.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@dailymotion/vast-client": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artegeie/videojs-vast",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "main": "./dist/cjs/index.js",
   "module": "./dist/mjs/index.js",
   "license": "Apache-2.0",


### PR DESCRIPTION
Release 1.7.4 — build target fix and the esbuild bump it unblocked.

## Contents

- **VAST-94** ([#131](https://github.com/ArteGEIE/videojs-vast/pull/131)) — The ESM target declared `['es2020', 'safari11']`, contradictory since Safari 11 predates ES2020. esbuild kept the most restrictive target and had to downlevel destructuring for Safari 11, which it cannot do below Safari 15. 0.27 stayed silent and emitted the code untransformed; 0.28 failed the build.
- **esbuild 0.27.3 to 0.28.2** ([#129](https://github.com/ArteGEIE/videojs-vast/pull/129)) — red since it was opened, green once rebased on the target fix.

## This one does change the published bundle

Unlike 1.7.3, integrators receive a different artifact:

| Artifact | Before | After |
|---|---|---|
| `dist/mjs/index.js` | 38 KB | **36 KB** |
| `dist/cjs/index.js` | 37 KB | 37 KB (unchanged) |

The only removed code is the `__spreadValues` helper set, emitted to transpile object spread for Safari 11. Native object spread is supported from **Safari 11.1**, and web-front declares `safari >= 12`, so no supported browser relied on it. The CommonJS build never declared a target, hence no change there.

Integrators supporting Safari 11.0 exactly would be affected. Worth noting that destructuring was never transpiled for that target either, so the guarantee `safari11` implied was not actually being produced.

## Verification on develop, with esbuild 0.28.2 installed

| Check | Result |
|---|---|
| `npm run lint` | pass |
| `npm run build` | pass |
| `npm run test:unit` | 31/31 |
| Cypress e2e | 11/11 |
| `npm audit --omit=dev` | 0 vulnerabilities |

## Follow-up

arteVp carries the identical contradiction in `packages/arteVp/esbuild.js:40`, tracked in PLAYER-3695 as a separate project.